### PR TITLE
python: update token expiration to 180 days

### DIFF
--- a/music_token.py
+++ b/music_token.py
@@ -14,7 +14,7 @@ teamId = "9876543210"
 alg = 'ES256'
 
 time_now = datetime.datetime.now()
-time_expired = datetime.datetime.now() + datetime.timedelta(hours=12)
+time_expired = datetime.datetime.now() + datetime.timedelta(hours=24*180)
 
 headers = {
 	"alg": alg,


### PR DESCRIPTION
match node behavior https://github.com/pelauimagineering/apple-music-token-generator/blob/master/create_token.js#L31

per [Apple docs](https://developer.apple.com/documentation/applemusicapi/generating_developer_tokens):

> The expiration time (exp) registered claim key, whose value must not be greater than 15777000 (6 months in seconds) from the current Unix time on the server

I tested generating a token locally and it works so far 