### PR TITLE
Fixing race condition in create_token.js

### DIFF
--- a/create_token.js
+++ b/create_token.js
@@ -79,10 +79,11 @@ if(process.argv.length >= 3 && process.env.TEAM_ID && process.env.KEY_ID){
                 privateKey = fs.readFileSync(response.privateKeyFilename);
             } catch (error) {
                 console.error(error);
+                return;
             }
-            payload.iss = response.teamId;
+            payload.iss = response.teamID;
             headers.kid = response.kid;
-            dataReady = true;
+            generateToken();
         })
         .catch(error => {
             console.error(error);
@@ -98,11 +99,12 @@ function writeToFile(fileName, data) {
 
 // JWT are formed formed like:
 // jwt.sign(payload, secretOrPrivateKey, [options, callback])
-if(dataReady) {
+function generateToken() {
     try {
     jwt.sign(payload, privateKey, {header: headers}, async function(error, token) {
         if(error){
             console.error(error);
+            console.log("error!");
             process.exit(1);
         }
 
@@ -141,7 +143,7 @@ if(dataReady) {
             return response.json();
         })
         .then(json => {
-            if(json) { 
+            if(json) {
                 console.log('✅ Test passed');
             } else {
                 console.log('❌ Test failed');
@@ -158,6 +160,9 @@ if(dataReady) {
     } catch(error) {
         console.error(error);
     }
-} else {
-    console.error("😬 The data was not properly processed to create a JWT.");
+}
+
+// Call generateToken if data was loaded synchronously (via env vars/args)
+if(dataReady) {
+    generateToken();
 }


### PR DESCRIPTION
Fix race condition in interactive prompt flow

 The inquirer.prompt() call is asynchronous, but the JWT generation code was checking dataReady synchronously before the user could answer the prompts. This caused the "data was not properly processed"  error to appear immediately.

Changes:

- Wrap JWT signing logic in generateToken() function
- Call generateToken() from inquirer .then() callback
- Fix typo: response.teamId -> response.teamID